### PR TITLE
Integrate dataset builder and stereo analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-# trion
+# Trion
+
+This repository contains the early modules for Triōn AI. It currently includes:
+
+- `pro_audio_analyzer.py`: advanced audio feature extraction using `librosa` and `soundfile`.
+- `pro_reference_manager.py`: a reference manager for storing and comparing audio analysis data.
+- `style_mapper.py`: simple mapping from differences to EQ/compression.
+- `ai_mapper.py`: AI powered suggestion engine that can run as a TFLite model.
+- `style_simulator.py`: orchestrates analysis and generates preset suggestions.
+- `ai_training.py`: tools to train the lightweight model for `ai_mapper`.
+- `interface_cli.py`: simple command line helper.
+- `streamlit_gui.py`: optional Streamlit UI to run the analysis from a browser.
+- `main.py`: unified CLI entry point for analysis, training and reference
+  management.
+- `preset_exporter.py`: writes suggestions in `.json`, `.xml`, `.reaper`, or `.vstpreset` formats.
+- `similarity_matcher.py`: finds the closest reference based on analysis features.
+- `advanced_features.py`: higher level extraction utilities for envelope,
+  ADSR estimation, harmonic and percussive separation, pitch contour (CREPE
+  fallback to PYIN) along with spectral statistics (contrast, rolloff) and
+  mel/FFT spectrogram generation.
+- `dsp_tools.py`: simple DSP helpers for STFT-based FFT, RMS, peak level,
+  zero crossing rate and core spectral metrics including contrast and rolloff.
+- `model_arch.py`: tiny neural network used for training and inference.
+- `train.py`: utility to train the lightweight model with simple augmentation.
+- `quantize.py`: converts a trained model to TFLite int8/float16.
+ - `ton_shaper.py`, `preset_mapper.py`: processing helpers for EQ, saturation,
+   compression and reverb along with metadata mapping.
+ - `inference.py`: run a TFLite model on an audio file.
+ - `bluetooth_patch.py`: compensates for Bluetooth codec losses and shapes the spectrum.
+
+## Requirements
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+These modules rely on `librosa`, `numpy`, `soundfile`, `scipy` and `tensorflow` for the optional AI features. Pitch detection uses `crepe` if installed.
+
+## CLI usage
+
+Analyze audio and export preset suggestions:
+
+```bash
+python main.py run input.wav --reference my_ref --output_path preset.json
+```
+
+Train the AI model from a dataset of ``.npz`` files:
+
+```bash
+python main.py train --data_path ./dataset --output_model_path model.tflite
+```
+
+Add a new reference recording:
+
+```bash
+python main.py add-ref my_ref path/to/audio.wav --metadata '{"studio": "Abbey Road"}'
+```
+
+Launch the Streamlit GUI:
+
+```bash
+streamlit run -m trion.streamlit_gui
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,133 @@
+# ==============================================================================
+# main.py - Triōn AI'ın Ana Giriş Noktası
+# ==============================================================================
+
+import argparse
+import json
+import sys
+import os
+
+from trion.pro_audio_analyzer import ProAudioAnalyzer
+from trion.pro_reference_manager import ProReferenceManager
+from trion.ai_mapper import AIMapper
+from trion.preset_exporter import PresetExporter
+from trion.style_simulator import StyleSimulator
+from trion.similarity_matcher import SimilarityMatcher
+from trion.advanced_features import (
+    analyze_audio,
+    extract_envelope,
+    extract_harmonic,
+    extract_pitch_contour,
+    extract_spectral_centroid,
+)
+from trion import ai_training
+
+
+def main() -> None:
+    """Triōn AI command line interface."""
+    parser = argparse.ArgumentParser(
+        description="Triōn AI Komut Satırı Arayüzü: Müzik için Akıllı Ses Mühendisi"
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser(
+        "run", help="Ses dosyasını analiz et ve stil önerileri üret"
+    )
+    run_parser.add_argument("audio_file", help="Analiz edilecek ses dosyası")
+    run_parser.add_argument(
+        "--reference",
+        help=(
+            "Karşılaştırılacak referansın adı. Boş bırakılırsa en yakın referans"
+            " otomatik seçilir."
+        ),
+    )
+    run_parser.add_argument(
+        "--output_format",
+        default="json",
+        choices=["json", "xml", "reaper", "vstpreset"],
+        help="Çıktı önayar dosyasının formatı",
+    )
+    run_parser.add_argument(
+        "--output_path", help="Çıktı önayar dosyasının kaydedileceği yol"
+    )
+    run_parser.add_argument(
+        "--model_path",
+        default="model.tflite",
+        help="AI Mapper için kullanılacak TFLite modeli",
+    )
+
+    train_parser = subparsers.add_parser("train", help="Triōn AI modelini eğit")
+    train_parser.add_argument(
+        "--data_path", required=True, help="Eğitim veri setinin bulunduğu dizin"
+    )
+    train_parser.add_argument(
+        "--output_model_path",
+        default="model.tflite",
+        help="Eğitilmiş modelin kaydedileceği yol",
+    )
+
+    add_ref_parser = subparsers.add_parser(
+        "add-ref", help="Yeni bir referans ses kaydı ekle"
+    )
+    add_ref_parser.add_argument("name", help="Referansın adı")
+    add_ref_parser.add_argument("audio_file", help="Ses dosyasının yolu")
+    add_ref_parser.add_argument(
+        "--metadata",
+        type=json.loads,
+        help='JSON formatında metadata (örneğin: {"studio": "Abbey Road"})',
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        mapper = AIMapper(model_path=args.model_path)
+        ref_manager = ProReferenceManager()
+        exporter = PresetExporter()
+        simulator = StyleSimulator(ref_manager, mapper, exporter)
+
+        try:
+            suggestions = simulator.process(
+                audio_path=args.audio_file,
+                reference_name=args.reference,
+                export_format=args.output_format if args.output_path else None,
+                export_path=args.output_path,
+            )
+            print("\nÖnerilen Ayarlar:")
+            for k, v in suggestions.items():
+                print(f"  {k}: {v:.4f}")
+            if args.output_path:
+                print(f"\nAyarlar kaydedildi: {args.output_path}")
+        except Exception as e:
+            print(f"Hata: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == "train":
+        try:
+            trained_model_path = ai_training.train(
+                args.data_path, args.output_model_path
+            )
+            print(
+                f"AI modeli başarıyla eğitildi ve kaydedildi: {trained_model_path}"
+            )
+        except Exception as e:
+            print(f"Hata: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.command == "add-ref":
+        ref_manager = ProReferenceManager()
+        try:
+            print(
+                f"'{args.name}' referansı için ses analizi yapılıyor (gelişmiş özellikler dahil)..."
+            )
+            analysis_results = analyze_audio(args.audio_file, mono=False)
+            ref_manager.add_reference(args.name, analysis_results, args.metadata)
+            ref_manager.save_references()
+            print(f"Referans '{args.name}' başarıyla eklendi.")
+        except Exception as e:
+            print(f"Hata: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+librosa
+numpy
+soundfile
+tensorflow
+scipy
+streamlit
+crepe
+pytest

--- a/src/pro_audio_analyzer.py
+++ b/src/pro_audio_analyzer.py
@@ -1,0 +1,112 @@
+# ==============================================================================
+# pro_audio_analyzer.py - Triōn AI için Ses Özelliği Çıkarıcı (Pro Versiyon)
+# ==============================================================================
+
+import librosa
+import numpy as np
+import soundfile as sf
+import os
+from typing import Dict, Union, List
+
+from trion.dsp_tools import compute_fft, compute_mfcc, dynamic_range
+from trion.advanced_features import (
+    extract_envelope,
+    extract_spectral_centroid,
+    extract_harmonic,
+    extract_pitch_contour,
+)
+
+class ProAudioAnalyzer:
+    """
+    Triōn AI için profesyonel seviyede ses özelliklerini çıkaran sınıf.
+    FLAC, WAV gibi çeşitli ses formatlarını destekler ve AI eğitimi için
+    kritik metrikleri sağlar.
+    """
+    def __init__(self, file_path: str):
+        """
+        Analiz edilecek ses dosyasını başlatır.
+
+        Args:
+            file_path (str): Ses dosyasının yolu (örn. .flac, .wav).
+        
+        Raises:
+            FileNotFoundError: Belirtilen dosya yolu bulunamazsa.
+            sf.LibsndfileError: Ses dosyası okunamıyorsa (bozuk format vb.).
+        """
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Ses dosyası bulunamadı: {file_path}")
+        
+        self.file_path = file_path
+        self.y: np.ndarray
+        self.sr: int
+
+        try:
+            # sf.read ile daha geniş format desteği ve hata yönetimi
+            self.y, self.sr = sf.read(file_path, dtype='float32') # float32 ile daha iyi çözünürlük
+            if len(self.y.shape) > 1:
+                # Stereo ise ortalama alarak mono'ya indirge, ancak stereo bilgiyi koruma opsiyonu da eklenebilir.
+                self.y = np.mean(self.y, axis=1)
+        except sf.LibsndfileError as e:
+            raise sf.LibsndfileError(f"Ses dosyası okunamadı veya format hatası: {file_path}. Hata: {e}")
+        except Exception as e:
+            raise Exception(f"Ses dosyasını yüklerken beklenmeyen bir hata oluştu: {file_path}. Hata: {e}")
+
+    def get_duration(self) -> float:
+        """Ses dosyasının süresini saniye cinsinden döndürür."""
+        return len(self.y) / self.sr
+
+    def get_rms(self) -> float:
+        """Sesin Ortalama Karekök Gücünü (RMS) döndürür. Sesin genel enerji seviyesini temsil eder."""
+        return float(np.sqrt(np.mean(self.y ** 2)))
+
+    def get_peak_amplitude(self) -> float:
+        """Sesin tepe genliğini döndürür. Dinamik aralık için kullanılır."""
+        return float(np.max(np.abs(self.y)))
+
+    def get_spectral_centroid(self) -> float:
+        """Spektral Santroidi döndürür. Sesin 'parlaklığını' veya 'tizliğini' gösterir."""
+        centroid = librosa.feature.spectral_centroid(y=self.y, sr=self.sr)
+        return float(np.mean(centroid))
+
+    def get_spectral_flatness(self) -> float:
+        """Spektral Düzlük'ü döndürür. Sesin tınısının ne kadar 'gürültülü' veya 'müzikal' olduğunu gösterir."""
+        flatness = librosa.feature.spectral_flatness(y=self.y)
+        return float(np.mean(flatness))
+
+    def get_zero_crossing_rate(self) -> float:
+        """Sıfır Geçiş Oranını (ZCR) döndürür."""
+        zcr = librosa.feature.zero_crossing_rate(y=self.y)
+        return float(np.mean(zcr))
+
+    def get_dynamic_range(self) -> float:
+        """Sesin Dinamik Aralığını (DR) dB cinsinden döndürür."""
+        return dynamic_range(self.y)
+
+    def get_mfccs(self, n_mfcc: int = 13) -> List[float]:
+        """Mel-Frequency Cepstral Coefficients (MFCCs) döndürür."""
+        mfccs = compute_mfcc(self.y, self.sr, n_mfcc=n_mfcc)
+        return np.mean(mfccs, axis=1).tolist()
+
+    def analyze(self) -> Dict[str, Union[float, List[float]]]:
+        """Ses dosyasının tüm anahtar özelliklerini içeren bir sözlük döndürür."""
+        envelope = extract_envelope(self.y, self.sr)
+        spec_centroid = extract_spectral_centroid(self.y, self.sr)
+        harmonic = extract_harmonic(self.y)
+        pitch, voiced = extract_pitch_contour(self.y, self.sr)
+
+        return {
+            "duration_sec": self.get_duration(),
+            "rms": self.get_rms(),
+            "peak_amplitude": self.get_peak_amplitude(),
+            "spectral_centroid": float(np.mean(spec_centroid)),
+            "spectral_flatness": self.get_spectral_flatness(),
+            "zero_crossing_rate": self.get_zero_crossing_rate(),
+            "dynamic_range_db": self.get_dynamic_range(),
+            "mfccs": self.get_mfccs(),
+            "envelope": envelope.tolist(),
+            "harmonic_rms": float(np.sqrt(np.mean(harmonic ** 2))),
+            "pitch_contour": pitch.tolist() if pitch is not None else None,
+            "voiced_flags": voiced.tolist() if voiced is not None else None,
+            "fft": compute_fft(self.y).tolist(),
+        }
+

--- a/tests/test_dsp_tools.py
+++ b/tests/test_dsp_tools.py
@@ -1,0 +1,92 @@
+# ======================================================================
+# tests/test_dsp_tools.py - tests for trion.dsp_tools
+# ======================================================================
+"""Pytest tests for the dsp_tools module."""
+
+import numpy as np
+import pytest
+
+from trion import dsp_tools
+
+SR = 44100
+DURATION = 1.0
+FREQ = 440.0
+T = np.linspace(0, DURATION, int(SR * DURATION), endpoint=False)
+SINE_WAVE = 0.5 * np.sin(2 * np.pi * FREQ * T)
+NOISY_SINE_WAVE = SINE_WAVE + np.random.normal(0, 0.1, SINE_WAVE.shape)
+SILENT_WAVE = np.zeros_like(SINE_WAVE)
+
+
+def test_rms():
+    assert pytest.approx(dsp_tools.rms(SINE_WAVE), rel=1e-3) == 0.5 / np.sqrt(2)
+    assert dsp_tools.rms(SILENT_WAVE) == 0.0
+    assert dsp_tools.rms(np.array([])) == 0.0
+
+
+def test_peak_amplitude():
+    assert pytest.approx(dsp_tools.peak_amplitude(SINE_WAVE)) == 0.5
+    assert dsp_tools.peak_amplitude(SILENT_WAVE) == 0.0
+    assert dsp_tools.peak_amplitude(np.array([])) == 0.0
+
+
+def test_dynamic_range():
+    expected = 20 * np.log10(np.sqrt(2))
+    assert pytest.approx(dsp_tools.dynamic_range(SINE_WAVE), abs=0.1) == expected
+    assert dsp_tools.dynamic_range(SILENT_WAVE) == 0.0
+
+
+def test_zero_crossing_rate():
+    assert dsp_tools.zero_crossing_rate(SINE_WAVE) > 0.01
+    assert dsp_tools.zero_crossing_rate(SILENT_WAVE) < 0.01
+
+
+def test_compute_fft():
+    fft_result = dsp_tools.compute_fft(SINE_WAVE)
+    assert fft_result.ndim == 2
+    assert np.all(fft_result >= 0)
+    assert fft_result.shape[0] > 0 and fft_result.shape[1] > 0
+
+
+def test_compute_mfcc():
+    mfcc_result = dsp_tools.compute_mfcc(SINE_WAVE, SR)
+    assert mfcc_result.ndim == 2
+    assert mfcc_result.shape[0] == 13
+    assert mfcc_result.shape[1] > 0
+
+
+def test_spectral_centroid():
+    centroid = dsp_tools.spectral_centroid(SINE_WAVE, SR)
+    assert pytest.approx(centroid, rel=0.1) == FREQ
+    assert centroid > 0.0
+
+
+def test_spectral_flatness():
+    flatness = dsp_tools.spectral_flatness(SINE_WAVE)
+    assert flatness < 0.1
+    assert flatness >= 0.0
+
+
+def test_spectral_bandwidth():
+    bandwidth = dsp_tools.spectral_bandwidth(SINE_WAVE, SR)
+    assert bandwidth > 0.0
+    assert bandwidth < 1000.0
+
+
+def test_spectral_contrast():
+    contrast = dsp_tools.spectral_contrast(SINE_WAVE, SR)
+    noisy_contrast = dsp_tools.spectral_contrast(NOISY_SINE_WAVE, SR)
+    assert contrast >= 0.0
+    assert noisy_contrast < contrast
+
+
+def test_spectral_rolloff():
+    rolloff = dsp_tools.spectral_rolloff(SINE_WAVE, SR)
+    assert rolloff > FREQ
+    assert rolloff < SR / 2
+
+
+def test_mel_spectrogram():
+    mel_spec_result = dsp_tools.mel_spectrogram(SINE_WAVE, SR, n_mels=64)
+    assert mel_spec_result.ndim == 2
+    assert mel_spec_result.shape[0] == 64
+    assert np.all(mel_spec_result >= 0.0)

--- a/trion/__init__.py
+++ b/trion/__init__.py
@@ -1,0 +1,94 @@
+"""Triōn AI modules."""
+
+from .pro_audio_analyzer import ProAudioAnalyzer
+from .pro_reference_manager import ProReferenceManager
+from .style_mapper import StyleMapper
+from .ai_mapper import AIMapper
+from . import ai_training
+from .style_simulator import StyleSimulator
+from .preset_exporter import PresetExporter
+from .similarity_matcher import SimilarityMatcher
+from .advanced_features import (
+    extract_envelope,
+    extract_spectral_centroid,
+    extract_spectral_flatness,
+    extract_spectral_bandwidth,
+    extract_spectral_contrast,
+    extract_spectral_rolloff,
+    extract_harmonic,
+    extract_percussive,
+    extract_pitch_contour,
+    extract_spectrogram,
+    extract_mel_spectrogram,
+    extract_adsr,
+    analyze_audio,
+)
+from .model_arch import build_model
+from .train import train
+from .quantize import quantize
+from .ton_shaper import apply_eq, saturate, widen_stereo, compress, add_reverb
+from .preset_mapper import map_metadata
+from .dsp_tools import (
+    compute_fft,
+    compute_mfcc,
+    dynamic_range,
+    rms as compute_rms,
+    peak_amplitude,
+    zero_crossing_rate,
+    spectral_centroid,
+    spectral_flatness,
+    spectral_bandwidth,
+    mel_spectrogram,
+)
+from .inference import process_file
+from .bluetooth_patch import apply_bt_correction
+from .streamlit_gui import main as streamlit_gui
+from .dataset_builder import analysis_to_flat_vector, build_dataset
+
+__all__ = [
+    "ProAudioAnalyzer",
+    "ProReferenceManager",
+    "StyleMapper",
+    "AIMapper",
+    "ai_training",
+    "StyleSimulator",
+    "PresetExporter",
+    "SimilarityMatcher",
+    "extract_envelope",
+    "extract_spectral_centroid",
+    "extract_spectral_flatness",
+    "extract_spectral_bandwidth",
+    "extract_spectral_contrast",
+    "extract_spectral_rolloff",
+    "extract_harmonic",
+    "extract_percussive",
+    "extract_pitch_contour",
+    "extract_spectrogram",
+    "extract_mel_spectrogram",
+    "extract_adsr",
+    "analyze_audio",
+    "build_model",
+    "train",
+    "quantize",
+    "apply_eq",
+    "saturate",
+    "widen_stereo",
+    "compress",
+    "add_reverb",
+    "map_metadata",
+    "compute_fft",
+    "compute_mfcc",
+    "dynamic_range",
+    "compute_rms",
+    "peak_amplitude",
+    "zero_crossing_rate",
+    "spectral_centroid",
+    "spectral_flatness",
+    "spectral_bandwidth",
+    "mel_spectrogram",
+    "process_file",
+    "apply_bt_correction",
+    "streamlit_gui",
+    "analysis_to_flat_vector",
+    "build_dataset",
+]

--- a/trion/advanced_features.py
+++ b/trion/advanced_features.py
@@ -1,0 +1,194 @@
+"""Advanced audio feature extraction utilities for Triōn AI.
+
+These functions build on :mod:`dsp_tools` to provide higher level
+descriptors such as amplitude envelope, harmonic content and pitch
+contour. They are used by the professional analyzer and the training
+pipeline.
+"""
+
+from typing import Tuple
+
+try:
+    import crepe  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    crepe = None
+
+from .dsp_tools import (
+    rms,
+    peak_amplitude,
+    dynamic_range,
+    zero_crossing_rate,
+    spectral_centroid as basic_spectral_centroid,
+    spectral_flatness as basic_spectral_flatness,
+    spectral_bandwidth as basic_spectral_bandwidth,
+    spectral_contrast as basic_spectral_contrast,
+    spectral_rolloff as basic_spectral_rolloff,
+    compute_mfcc,
+    compute_fft,
+)
+
+import librosa
+import soundfile as sf
+import numpy as np
+import scipy.signal
+
+
+def extract_envelope(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Return the amplitude envelope using a Hilbert transform."""
+    analytic_signal = scipy.signal.hilbert(audio)
+    return np.abs(analytic_signal)
+
+
+def extract_adsr(envelope: np.ndarray, sr: int) -> Tuple[float, float, float, float]:
+    """Return simple ADSR characteristics from an amplitude envelope."""
+    if len(envelope) == 0:
+        return 0.0, 0.0, 0.0, 0.0
+    env = envelope / np.max(np.abs(envelope))
+    attack_idx = np.argmax(env > 0.1)
+    decay_idx = np.argmax(env[attack_idx:] < 0.8) + attack_idx if attack_idx < len(env) else attack_idx
+    sustain_level = float(np.median(env[decay_idx:])) if decay_idx < len(env) else 0.0
+    release_idx = len(env) - np.argmax(env[::-1] > 0.1) - 1
+    return attack_idx / sr, decay_idx / sr, sustain_level, release_idx / sr
+
+
+def extract_spectral_centroid(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Return the spectral centroid over time."""
+    return librosa.feature.spectral_centroid(y=audio, sr=sr)[0]
+
+
+def extract_spectral_flatness(audio: np.ndarray) -> np.ndarray:
+    """Return spectral flatness values over time."""
+    return librosa.feature.spectral_flatness(y=audio)[0]
+
+
+def extract_spectral_bandwidth(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Return spectral bandwidth over time."""
+    return librosa.feature.spectral_bandwidth(y=audio, sr=sr)[0]
+
+
+def extract_spectral_contrast(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Return spectral contrast over time."""
+    return librosa.feature.spectral_contrast(y=audio, sr=sr)[0]
+
+
+def extract_spectral_rolloff(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Return spectral rolloff over time."""
+    return librosa.feature.spectral_rolloff(y=audio, sr=sr)[0]
+
+
+def extract_harmonic(audio: np.ndarray) -> np.ndarray:
+    """Return the harmonic component of the signal."""
+    harmonic, _ = librosa.effects.hpss(audio)
+    return harmonic
+
+
+def extract_percussive(audio: np.ndarray) -> np.ndarray:
+    """Return the percussive component of the signal."""
+    _, percussive = librosa.effects.hpss(audio)
+    return percussive
+
+
+def extract_pitch_contour(audio: np.ndarray, sr: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Return pitch contour using CREPE if available, otherwise PYIN."""
+    if crepe is not None:
+        audio_f32 = librosa.util.normalize(audio.astype(np.float32))
+        time, frequency, confidence, _ = crepe.predict(
+            audio_f32, sr, viterbi=True, step_size=100
+        )
+        voiced = confidence > 0.5
+        return frequency, voiced
+    pitches, voiced_flags, _ = librosa.pyin(
+        audio,
+        fmin=librosa.note_to_hz("C2"),
+        fmax=librosa.note_to_hz("C7"),
+    )
+    return pitches, voiced_flags
+
+
+def extract_spectrogram(audio: np.ndarray, sr: int, n_fft: int = 1024, hop_length: int = 512) -> np.ndarray:
+    """Return magnitude spectrogram."""
+    spec = np.abs(librosa.stft(audio, n_fft=n_fft, hop_length=hop_length))
+    return spec
+
+
+def extract_mel_spectrogram(audio: np.ndarray, sr: int, n_fft: int = 1024, hop_length: int = 512, n_mels: int = 128) -> np.ndarray:
+    """Return mel-scaled spectrogram."""
+    spec = librosa.feature.melspectrogram(y=audio, sr=sr, n_fft=n_fft, hop_length=hop_length, n_mels=n_mels)
+    return librosa.power_to_db(spec)
+
+
+def analyze_audio(file_path: str, mono: bool = True) -> dict:
+    """Load audio and compute advanced features.
+
+    Parameters
+    ----------
+    file_path: str
+        Path to the audio file.
+    mono: bool, optional
+        If ``True`` the audio is mixed down to mono. If ``False`` each channel is
+        averaged after feature extraction.
+    """
+    y_raw, sr = sf.read(file_path, dtype="float32")
+    num_channels = y_raw.shape[1] if y_raw.ndim > 1 else 1
+    if y_raw.ndim > 1:
+        audio_mono = y_raw.mean(axis=1)
+    else:
+        audio_mono = y_raw
+    if mono:
+        audio = audio_mono
+    else:
+        audio = y_raw if y_raw.ndim == 1 else y_raw.T
+    envelope = extract_envelope(audio, sr)
+    adsr = extract_adsr(envelope, sr)
+    spectral_centroid = extract_spectral_centroid(audio, sr)
+    harmonic = extract_harmonic(audio)
+    percussive = extract_percussive(audio)
+    pitch_contour, voiced_flags = extract_pitch_contour(audio, sr)
+    flatness = extract_spectral_flatness(audio)
+    bandwidth = extract_spectral_bandwidth(audio, sr)
+    contrast = basic_spectral_contrast(audio, sr)
+    rolloff = basic_spectral_rolloff(audio, sr)
+    spectrogram = extract_spectrogram(audio, sr)
+    mel_spec = extract_mel_spectrogram(audio, sr)
+    mfcc = compute_mfcc(audio_mono, sr, n_mfcc=13)
+    fft = compute_fft(audio_mono)
+    base_metrics = {
+        "rms": rms(audio_mono),
+        "peak_amplitude": peak_amplitude(audio_mono),
+        "dynamic_range_db": dynamic_range(audio_mono),
+        "zero_crossing_rate": zero_crossing_rate(audio_mono),
+        "spectral_centroid_mean": basic_spectral_centroid(audio_mono, sr),
+        "spectral_flatness_mean": basic_spectral_flatness(audio_mono),
+        "spectral_bandwidth_mean": basic_spectral_bandwidth(audio_mono, sr),
+        "spectral_contrast_mean": float(np.mean(contrast)),
+        "spectral_rolloff_mean": float(np.mean(rolloff)),
+    }
+
+    return {
+        **base_metrics,
+        "envelope": envelope.tolist(),
+        "adsr": {
+            "attack_sec": adsr[0],
+            "decay_sec": adsr[1],
+            "sustain_level": adsr[2],
+            "release_sec": adsr[3],
+        },
+        "spectral_centroid": spectral_centroid.tolist(),
+        "spectral_flatness": flatness.tolist(),
+        "spectral_bandwidth": bandwidth.tolist(),
+        "spectrogram": spectrogram.tolist(),
+        "mel_spectrogram": mel_spec.tolist(),
+        "harmonic": harmonic.tolist(),
+        "percussive_rms": float(rms(percussive)),
+        "pitch_contour": pitch_contour.tolist() if pitch_contour is not None else None,
+        "voiced_flags": voiced_flags.tolist() if voiced_flags is not None else None,
+        "mfcc": mfcc.mean(axis=1).tolist(),
+        "fft": fft.tolist(),
+        "spectral_contrast": contrast.tolist(),
+        "spectral_rolloff": rolloff.tolist(),
+        "num_channels": num_channels,
+        "sr": sr,
+    }
+
+
+

--- a/trion/ai_mapper.py
+++ b/trion/ai_mapper.py
@@ -1,0 +1,112 @@
+# =============================================================================
+# ai_mapper.py - AI powered mapping of audio differences to processing parameters
+# =============================================================================
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Union, Optional
+
+import numpy as np
+
+try:
+    import tensorflow as tf
+except Exception:  # pragma: no cover - tensorflow may not be installed
+    tf = None
+
+
+class AIMapper:
+    """Map analysis differences to processing suggestions using a lightweight AI model."""
+
+    def __init__(self, model_path: Optional[str] = None) -> None:
+        self.model_path = model_path
+        self.interpreter: Optional[tf.lite.Interpreter] = None
+        if tf is not None and model_path and os.path.exists(model_path):
+            self.interpreter = tf.lite.Interpreter(model_path=model_path)
+            self.interpreter.allocate_tensors()
+
+    def _run_model(self, features: np.ndarray) -> Optional[np.ndarray]:
+        if self.interpreter is None:
+            return None
+        input_details = self.interpreter.get_input_details()
+        output_details = self.interpreter.get_output_details()
+        self.interpreter.set_tensor(input_details[0]["index"], features.astype(np.float32))
+        self.interpreter.invoke()
+        output = self.interpreter.get_tensor(output_details[0]["index"])
+        return output.squeeze()
+
+    def suggest_processing(
+        self,
+        target_analysis: Dict[str, Union[float, List[float]]],
+        references: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, float]:
+        """Return processing suggestions based on target analysis and references."""
+        # Aggregate reference analyses for simple feature context
+        if references:
+            ref_vals = [r.get("analysis", {}) for r in references.values()]
+            avg_ref = {
+                k: float(np.mean([rv.get(k, 0.0) for rv in ref_vals]))
+                for k in target_analysis
+                if isinstance(target_analysis[k], (int, float))
+            }
+        else:
+            avg_ref = {k: 0.0 for k in target_analysis if isinstance(target_analysis[k], (int, float))}
+
+        feature_keys = sorted(avg_ref)
+        features = np.array([[target_analysis.get(k, 0.0) - avg_ref.get(k, 0.0) for k in feature_keys]])
+        model_output = self._run_model(features)
+
+        if model_output is not None:
+            keys = [
+                "eq_mid_freq",
+                "eq_mid_gain_db",
+                "compressor_threshold_db",
+                "saturation_amount",
+                "reverb_mix",
+            ]
+            return {k: float(v) for k, v in zip(keys, model_output.tolist())}
+
+        # Fallback heuristic if model not available
+        suggestions: Dict[str, float] = {}
+        idx = {k: i for i, k in enumerate(feature_keys)}
+        centroid_diff = features[0][idx.get("spectral_centroid", 0)]
+        flatness_diff = features[0][idx.get("spectral_flatness_mean", 0)] if "spectral_flatness_mean" in idx else 0.0
+        rms_diff = features[0][idx.get("rms", 0)]
+        dyn_diff = features[0][idx.get("dynamic_range_db", 0)] if "dynamic_range_db" in idx else 0.0
+        contrast_diff = features[0][idx.get("spectral_contrast_mean", 0)] if "spectral_contrast_mean" in idx else 0.0
+        rolloff_diff = features[0][idx.get("spectral_rolloff_mean", 0)] if "spectral_rolloff_mean" in idx else 0.0
+
+        if centroid_diff > 300:
+            suggestions["eq_mid_freq"] = 2000.0
+            suggestions["eq_mid_gain_db"] = -3.0
+        elif centroid_diff < -300:
+            suggestions["eq_mid_freq"] = 800.0
+            suggestions["eq_mid_gain_db"] = 3.0
+
+        if rms_diff > 0.1:
+            suggestions["compressor_threshold_db"] = -20.0
+        elif rms_diff < -0.1:
+            suggestions["compressor_threshold_db"] = -10.0
+
+        if flatness_diff > 0.1:
+            suggestions["saturation_amount"] = 0.2
+        else:
+            suggestions["saturation_amount"] = 0.1
+
+        if contrast_diff < -2:
+            suggestions["eq_high_shelf_db"] = 2.0
+        elif contrast_diff > 2:
+            suggestions["eq_high_shelf_db"] = -2.0
+
+        if rolloff_diff < -500:
+            suggestions["low_pass_freq"] = 8000.0
+        elif rolloff_diff > 500:
+            suggestions["low_pass_freq"] = 12000.0
+
+        if dyn_diff < -3:
+            suggestions["reverb_mix"] = 0.03
+        elif dyn_diff > 3:
+            suggestions["reverb_mix"] = 0.07
+        else:
+            suggestions["reverb_mix"] = 0.05
+        return suggestions

--- a/trion/ai_training.py
+++ b/trion/ai_training.py
@@ -1,0 +1,87 @@
+# =============================================================================
+# ai_training.py - training pipeline for the lightweight AI model
+# =============================================================================
+
+from __future__ import annotations
+
+import os
+from typing import List, Tuple, Dict, Any
+
+import numpy as np
+
+try:
+    import tensorflow as tf
+    from tensorflow import keras
+    from .model_arch import build_model
+except Exception:  # pragma: no cover - tensorflow may not be installed
+    tf = None
+    keras = None
+
+
+def load_dataset(data_path: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Load training data from the given path.
+
+    The directory is expected to contain numpy ``.npz`` files with ``features``
+    and ``targets`` arrays. This function stacks them into one dataset.
+    """
+    features_list: List[np.ndarray] = []
+    targets_list: List[np.ndarray] = []
+    for fname in os.listdir(data_path):
+        if fname.endswith(".npz"):
+            data = np.load(os.path.join(data_path, fname))
+            features_list.append(data["features"])  # shape (N, F)
+            targets_list.append(data["targets"])   # shape (N, T)
+    if not features_list:
+        raise ValueError("No training data found in " + data_path)
+    return np.vstack(features_list), np.vstack(targets_list)
+
+
+def analysis_to_vector(analysis: Dict[str, Any]) -> np.ndarray:
+    """Convert an analysis dictionary to a flat feature vector."""
+    vec: List[float] = []
+    keys = [
+        "rms",
+        "peak_amplitude",
+        "dynamic_range_db",
+        "zero_crossing_rate",
+        "spectral_centroid_mean",
+        "spectral_flatness_mean",
+        "spectral_bandwidth_mean",
+        "spectral_contrast_mean",
+        "spectral_rolloff_mean",
+    ]
+    for k in keys:
+        vec.append(float(analysis.get(k, 0.0)))
+    adsr = analysis.get("adsr", {})
+    vec.extend([
+        float(adsr.get("attack_sec", 0.0)),
+        float(adsr.get("decay_sec", 0.0)),
+        float(adsr.get("sustain_level", 0.0)),
+        float(adsr.get("release_sec", 0.0)),
+    ])
+    mfcc = analysis.get("mfcc")
+    if isinstance(mfcc, list):
+        vec.extend([float(x) for x in mfcc])
+    return np.array(vec, dtype=np.float32)
+
+
+def train(data_path: str, output_model_path: str) -> str:
+    """Train a small neural network and export as a TFLite model."""
+    if tf is None:
+        raise RuntimeError("TensorFlow not installed")
+
+    x, y = load_dataset(data_path)
+
+    noise = np.random.normal(0, 0.001, size=x.shape)
+    x_aug = np.concatenate([x, x + noise])
+    y_aug = np.concatenate([y, y])
+
+    model = build_model(x_aug.shape[1], y_aug.shape[1])
+    model.compile(optimizer="adam", loss="mse")
+    model.fit(x_aug, y_aug, epochs=25, batch_size=16)
+
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    tflite_model = converter.convert()
+    with open(output_model_path, "wb") as f:
+        f.write(tflite_model)
+    return output_model_path

--- a/trion/bluetooth_patch.py
+++ b/trion/bluetooth_patch.py
@@ -1,0 +1,19 @@
+# ======================================================================
+# bluetooth_patch.py - Simple correction for Bluetooth codec artifacts
+# ======================================================================
+"""Applies EQ adjustments to compensate for codec loss."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import butter, filtfilt
+
+
+def apply_bt_correction(audio: np.ndarray, sr: int) -> np.ndarray:
+    """Boost high frequencies to compensate for Bluetooth compression."""
+    b, a = butter(2, 4000 / (sr / 2), btype="high")
+    high = filtfilt(b, a, audio)
+    low_b, low_a = butter(2, 200 / (sr / 2), btype="low")
+    low = filtfilt(low_b, low_a, audio)
+    corrected = audio + 0.5 * high - 0.1 * low
+    return corrected

--- a/trion/dataset_builder.py
+++ b/trion/dataset_builder.py
@@ -1,0 +1,126 @@
+# ======================================================================
+# trion/dataset_builder.py - AI training dataset creation helpers
+# ======================================================================
+"""Utilities to build training datasets from audio files and references."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Any, List
+
+import numpy as np
+
+from .advanced_features import analyze_audio
+from .pro_reference_manager import ProReferenceManager
+
+
+def analysis_to_flat_vector(analysis: Dict[str, Any]) -> np.ndarray:
+    """Convert analysis dictionary to a flat feature vector."""
+    vec: List[float] = []
+    scalar_keys = [
+        "rms",
+        "peak_amplitude",
+        "dynamic_range_db",
+        "zero_crossing_rate",
+        "spectral_centroid_mean",
+        "spectral_flatness_mean",
+        "spectral_bandwidth_mean",
+        "spectral_contrast_mean",
+        "spectral_rolloff_mean",
+        "harmonic_rms",
+        "percussive_rms",
+        "num_channels",
+        "sr",
+    ]
+    for k in scalar_keys:
+        vec.append(float(analysis.get(k, 0.0)))
+    adsr = analysis.get("adsr", {})
+    vec.extend([
+        float(adsr.get("attack_sec", 0.0)),
+        float(adsr.get("decay_sec", 0.0)),
+        float(adsr.get("sustain_level", 0.0)),
+        float(adsr.get("release_sec", 0.0)),
+    ])
+    mfcc = analysis.get("mfcc") or analysis.get("mfccs")
+    if isinstance(mfcc, list):
+        vec.extend(float(x) for x in mfcc)
+    elif isinstance(mfcc, np.ndarray):
+        vec.extend(mfcc.flatten().tolist())
+    pitch = analysis.get("pitch_contour")
+    if isinstance(pitch, list) and pitch:
+        pitches = np.array([p for p in pitch if p and not np.isnan(p)])
+        if pitches.size:
+            vec.extend([
+                float(np.mean(pitches)),
+                float(np.min(pitches)),
+                float(np.max(pitches)),
+                float(np.std(pitches)),
+            ])
+        else:
+            vec.extend([0.0, 0.0, 0.0, 0.0])
+    else:
+        vec.extend([0.0, 0.0, 0.0, 0.0])
+    mel_spec = analysis.get("mel_spectrogram_db") or analysis.get("mel_spectrogram")
+    if isinstance(mel_spec, list) and mel_spec:
+        arr = np.array(mel_spec)
+        vec.extend([float(np.mean(arr)), float(np.std(arr))])
+    else:
+        vec.extend([0.0, 0.0])
+    fft = analysis.get("fft_magnitude") or analysis.get("fft")
+    if isinstance(fft, list) and fft:
+        arr = np.array(fft)
+        vec.extend([float(np.mean(arr)), float(np.std(arr))])
+    else:
+        vec.extend([0.0, 0.0])
+    return np.array(vec, dtype=np.float32)
+
+
+def generate_target_vector(
+    target_params_template: Dict[str, float]
+) -> np.ndarray:
+    """Create a target vector from a parameter template."""
+    keys = [
+        "eq_mid_freq",
+        "eq_mid_gain_db",
+        "compressor_threshold_db",
+        "saturation_amount",
+        "reverb_mix",
+        "stereo_width_ratio",
+        "low_pass_freq",
+        "high_pass_freq",
+        "adsr_attack_target",
+        "adsr_decay_target",
+        "harmonic_boost_amount",
+        "percussive_boost_amount",
+    ]
+    return np.array([float(target_params_template.get(k, 0.0)) for k in keys], dtype=np.float32)
+
+
+def build_dataset(
+    audio_files_dir: str,
+    output_dir: str,
+    reference_manager: ProReferenceManager,
+    target_processing_templates: Dict[str, Dict[str, float]],
+) -> None:
+    """Generate .npz training data from audio files and templates."""
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    for name, ref in reference_manager.references.items():
+        file_path = ref.get("metadata", {}).get("file_path")
+        if not file_path:
+            continue
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(audio_files_dir, file_path)
+        if not os.path.exists(file_path):
+            continue
+        try:
+            analysis = analyze_audio(file_path, mono=True)
+        except Exception:
+            continue
+        features = analysis_to_flat_vector(analysis)
+        targets = generate_target_vector(target_processing_templates.get(name, {}))
+        out_path = os.path.join(output_dir, f"{name}_data.npz")
+        np.savez_compressed(out_path, features=features, targets=targets)
+    print("Dataset creation complete.")
+
+__all__ = ["analysis_to_flat_vector", "build_dataset"]

--- a/trion/dsp_tools.py
+++ b/trion/dsp_tools.py
@@ -1,0 +1,88 @@
+# ======================================================================
+# dsp_tools.py - Basic DSP helper functions
+# ======================================================================
+"""Utility functions for common digital signal processing tasks.
+
+These helpers provide basic audio metrics like RMS, peak amplitude,
+zero crossing rate and spectral statistics. They are lightweight so
+other modules can reuse them without pulling in large dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import librosa
+import scipy.signal
+
+
+def compute_fft(audio: np.ndarray) -> np.ndarray:
+    """Return magnitude spectrum of the audio using STFT."""
+    spec = librosa.stft(audio)
+    return np.abs(spec)
+
+
+def compute_mfcc(audio: np.ndarray, sr: int, n_mfcc: int = 13) -> np.ndarray:
+    return librosa.feature.mfcc(y=audio, sr=sr, n_mfcc=n_mfcc)
+
+
+def dynamic_range(audio: np.ndarray) -> float:
+    if audio.size == 0:
+        return 0.0
+    rms_val = np.sqrt(np.mean(audio ** 2))
+    peak = np.max(np.abs(audio)) if audio.size else 0.0
+    if rms_val <= 1e-9:
+        return 0.0
+    return float(20 * np.log10(peak / rms_val))
+
+
+def rms(audio: np.ndarray) -> float:
+    """Return root mean square of the signal."""
+    if audio.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(audio ** 2)))
+
+
+def peak_amplitude(audio: np.ndarray) -> float:
+    """Return peak absolute amplitude of the signal."""
+    if audio.size == 0:
+        return 0.0
+    return float(np.max(np.abs(audio)))
+
+
+def zero_crossing_rate(audio: np.ndarray) -> float:
+    """Average zero crossing rate of the signal."""
+    return float(np.mean(librosa.feature.zero_crossing_rate(y=audio)))
+
+
+def spectral_centroid(audio: np.ndarray, sr: int) -> float:
+    """Mean spectral centroid."""
+    return float(np.mean(librosa.feature.spectral_centroid(y=audio, sr=sr)))
+
+
+def spectral_flatness(audio: np.ndarray) -> float:
+    """Mean spectral flatness."""
+    return float(np.mean(librosa.feature.spectral_flatness(y=audio)))
+
+
+def spectral_bandwidth(audio: np.ndarray, sr: int) -> float:
+    """Mean spectral bandwidth."""
+    return float(np.mean(librosa.feature.spectral_bandwidth(y=audio, sr=sr)))
+
+
+def spectral_contrast(audio: np.ndarray, sr: int) -> float:
+    """Mean spectral contrast."""
+    return float(np.mean(librosa.feature.spectral_contrast(y=audio, sr=sr)))
+
+
+def spectral_rolloff(audio: np.ndarray, sr: int) -> float:
+    """Mean spectral rolloff frequency."""
+    return float(np.mean(librosa.feature.spectral_rolloff(y=audio, sr=sr)))
+
+
+def mel_spectrogram(audio: np.ndarray, sr: int, n_mels: int = 64) -> np.ndarray:
+    """Mel-scaled spectrogram."""
+    return librosa.feature.melspectrogram(y=audio, sr=sr, n_mels=n_mels)
+
+

--- a/trion/inference.py
+++ b/trion/inference.py
@@ -1,0 +1,46 @@
+# ======================================================================
+# inference.py - Run trained model on audio chunks
+# ======================================================================
+"""Pipeline for applying the trained model to audio."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+import numpy as np
+
+try:
+    import tensorflow as tf
+except Exception:  # pragma: no cover - tensorflow may not be installed
+    tf = None
+
+from .pro_audio_analyzer import ProAudioAnalyzer
+from .ton_shaper import apply_eq, saturate
+
+
+def process_file(audio_path: str, model_path: str) -> Dict[str, float]:
+    if tf is None:
+        raise RuntimeError("TensorFlow is required for inference")
+
+    interpreter = tf.lite.Interpreter(model_path=model_path)
+    interpreter.allocate_tensors()
+    input_details = interpreter.get_input_details()
+    output_details = interpreter.get_output_details()
+
+    analyzer = ProAudioAnalyzer(audio_path)
+    analysis = analyzer.analyze()
+
+    features = np.array([[analysis.get(k, 0.0) for k in sorted(analysis) if isinstance(analysis[k], (int, float))]])
+    interpreter.set_tensor(input_details[0]["index"], features.astype(np.float32))
+    interpreter.invoke()
+    output = interpreter.get_tensor(output_details[0]["index"]).squeeze().tolist()
+
+    # simple post processing using ton_shaper
+    processed = {
+        "eq_mid_freq": output[0],
+        "eq_mid_gain_db": output[1],
+        "compressor_threshold_db": output[2],
+        "saturation_amount": output[3],
+        "reverb_mix": output[4],
+    }
+    return processed

--- a/trion/interface_cli.py
+++ b/trion/interface_cli.py
@@ -1,0 +1,58 @@
+# =============================================================================
+# interface_cli.py - Simple command line interface for Triōn
+# =============================================================================
+
+import argparse
+from .pro_reference_manager import ProReferenceManager
+from .ai_mapper import AIMapper
+from .preset_exporter import PresetExporter
+from .style_simulator import StyleSimulator
+from . import ai_training
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Triōn command line interface")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_p = sub.add_parser("run", help="Analyze audio and suggest processing")
+    run_p.add_argument("audio_file", help="Path to the audio file to analyze")
+    run_p.add_argument(
+        "--reference",
+        help="Name of the reference to compare (optional, will auto select)",
+    )
+    run_p.add_argument("--format", default="json", help="Export format")
+    run_p.add_argument("--output", help="Output preset file path")
+    run_p.add_argument(
+        "--model_path",
+        default="model.tflite",
+        help="Path to the AI model used by the mapper",
+    )
+
+    train_p = sub.add_parser("train", help="Train the AI model")
+    train_p.add_argument("--data_path", required=True, help="Path to training dataset")
+    train_p.add_argument("--output_model_path", required=True, help="Where to save the trained model")
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        ref_manager = ProReferenceManager()
+        mapper = AIMapper(model_path=args.model_path)
+        exporter = PresetExporter()
+        simulator = StyleSimulator(ref_manager, mapper, exporter)
+
+        suggestions = simulator.process(
+            args.audio_file,
+            reference_name=args.reference,
+            export_format=args.format if args.output else None,
+            export_path=args.output,
+        )
+
+        print("Suggested settings:")
+        for k, v in suggestions.items():
+            print(f"  {k}: {v}")
+    elif args.command == "train":
+        ai_training.train(args.data_path, args.output_model_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/trion/model_arch.py
+++ b/trion/model_arch.py
@@ -1,0 +1,35 @@
+# ======================================================================
+# model_arch.py - Tiny MLP architecture for Tri\u014dn AI
+# ======================================================================
+"""Lightweight model definition used for training and inference."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    import tensorflow as tf
+except Exception:  # pragma: no cover - tensorflow may not be installed
+    tf = None
+
+
+def build_model(input_dim: int, output_dim: int) -> "tf.keras.Model":
+    """Build a small MLP with around 1000 parameters.
+
+    Parameters
+    ----------
+    input_dim: int
+        Number of input features.
+    output_dim: int
+        Number of output parameters.
+    """
+    if tf is None:
+        raise RuntimeError("TensorFlow is required to build the model")
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.InputLayer(input_shape=(input_dim,)),
+        tf.keras.layers.Dense(24, activation="relu"),
+        tf.keras.layers.Dense(16, activation="relu"),
+        tf.keras.layers.Dense(output_dim),
+    ])
+    return model

--- a/trion/preset_exporter.py
+++ b/trion/preset_exporter.py
@@ -1,0 +1,34 @@
+# =============================================================================
+# preset_exporter.py - Export preset suggestions in various formats
+# =============================================================================
+
+import json
+import xml.etree.ElementTree as ET
+from typing import Dict
+
+
+class PresetExporter:
+    """Exports preset suggestions in multiple formats."""
+
+    def export(self, settings: Dict[str, float], fmt: str, path: str) -> str:
+        fmt = fmt.lower()
+        if fmt == "json":
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(settings, f, indent=4)
+        elif fmt == "xml":
+            root = ET.Element("preset")
+            for k, v in settings.items():
+                el = ET.SubElement(root, k)
+                el.text = str(v)
+            tree = ET.ElementTree(root)
+            tree.write(path, encoding="utf-8")
+        elif fmt == "reaper":
+            with open(path, "w", encoding="utf-8") as f:
+                for k, v in settings.items():
+                    f.write(f"{k}={v}\n")
+        elif fmt == "vstpreset":
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(settings, f)
+        else:
+            raise ValueError(f"Unknown format: {fmt}")
+        return path

--- a/trion/preset_mapper.py
+++ b/trion/preset_mapper.py
@@ -1,0 +1,18 @@
+# ======================================================================
+# preset_mapper.py - Map metadata to preset templates
+# ======================================================================
+"""Provides preset defaults based on reference metadata."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+_PRESETS = {
+    "abbey_road": {"eq_mid_freq": 1000.0, "reverb_mix": 0.1},
+    "sunset_sound": {"eq_mid_freq": 1500.0, "reverb_mix": 0.05},
+}
+
+
+def map_metadata(metadata: Dict[str, str]) -> Dict[str, float]:
+    studio = metadata.get("studio", "").lower()
+    return _PRESETS.get(studio, {})

--- a/trion/pro_audio_analyzer.py
+++ b/trion/pro_audio_analyzer.py
@@ -1,0 +1,111 @@
+# ==============================================================================
+# pro_audio_analyzer.py - Triōn AI için Ses Özelliği Çıkarıcı (Pro Versiyon)
+# ==============================================================================
+
+import librosa
+import numpy as np
+import soundfile as sf
+import os
+from typing import Dict, Union, List
+
+from .dsp_tools import compute_fft, compute_mfcc, dynamic_range
+from .advanced_features import (
+    extract_envelope,
+    extract_spectral_centroid,
+    extract_harmonic,
+    extract_pitch_contour,
+)
+
+class ProAudioAnalyzer:
+    """Professional audio analysis helper for Triōn AI."""
+
+    def __init__(self, file_path: str, mono: bool = True):
+        """
+        Analiz edilecek ses dosyasını başlatır.
+
+        Args:
+            file_path (str): Ses dosyasının yolu.
+            mono (bool, optional): ``True`` ise sesi mono'ya çevirir, ``False``
+                ise varsa stereo kanalları korur.
+
+        Raises:
+            FileNotFoundError: Belirtilen dosya yolu bulunamazsa.
+            sf.LibsndfileError: Ses dosyası okunamıyorsa (bozuk format vb.).
+        """
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Ses dosyası bulunamadı: {file_path}")
+        
+        self.file_path = file_path
+        self.y: np.ndarray
+        self.sr: int
+
+        try:
+            # sf.read ile daha geniş format desteği ve hata yönetimi
+            self.y, self.sr = sf.read(file_path, dtype="float32")
+            if len(self.y.shape) > 1 and mono:
+                # Stereo ise ve mono isteniyorsa kanalları ortala
+                self.y = np.mean(self.y, axis=1)
+        except sf.LibsndfileError as e:
+            raise sf.LibsndfileError(f"Ses dosyası okunamadı veya format hatası: {file_path}. Hata: {e}")
+        except Exception as e:
+            raise Exception(f"Ses dosyasını yüklerken beklenmeyen bir hata oluştu: {file_path}. Hata: {e}")
+
+    def get_duration(self) -> float:
+        """Ses dosyasının süresini saniye cinsinden döndürür."""
+        return len(self.y) / self.sr
+
+    def get_rms(self) -> float:
+        """Sesin Ortalama Karekök Gücünü (RMS) döndürür. Sesin genel enerji seviyesini temsil eder."""
+        return float(np.sqrt(np.mean(self.y ** 2)))
+
+    def get_peak_amplitude(self) -> float:
+        """Sesin tepe genliğini döndürür. Dinamik aralık için kullanılır."""
+        return float(np.max(np.abs(self.y)))
+
+    def get_spectral_centroid(self) -> float:
+        """Spektral Santroidi döndürür. Sesin 'parlaklığını' veya 'tizliğini' gösterir."""
+        centroid = librosa.feature.spectral_centroid(y=self.y, sr=self.sr)
+        return float(np.mean(centroid))
+
+    def get_spectral_flatness(self) -> float:
+        """Spektral Düzlük'ü döndürür. Sesin tınısının ne kadar 'gürültülü' veya 'müzikal' olduğunu gösterir."""
+        flatness = librosa.feature.spectral_flatness(y=self.y)
+        return float(np.mean(flatness))
+
+    def get_zero_crossing_rate(self) -> float:
+        """Sıfır Geçiş Oranını (ZCR) döndürür."""
+        zcr = librosa.feature.zero_crossing_rate(y=self.y)
+        return float(np.mean(zcr))
+
+    def get_dynamic_range(self) -> float:
+        """Sesin Dinamik Aralığını (DR) dB cinsinden döndürür."""
+        return dynamic_range(self.y)
+
+    def get_mfccs(self, n_mfcc: int = 13) -> List[float]:
+        """Mel-Frequency Cepstral Coefficients (MFCCs) döndürür."""
+        mfccs = compute_mfcc(self.y, self.sr, n_mfcc=n_mfcc)
+        return np.mean(mfccs, axis=1).tolist()
+
+    def analyze(self) -> Dict[str, Union[float, List[float]]]:
+        """Ses dosyasının tüm anahtar özelliklerini içeren bir sözlük döndürür."""
+        envelope = extract_envelope(self.y, self.sr)
+        spec_centroid = extract_spectral_centroid(self.y, self.sr)
+        harmonic = extract_harmonic(self.y)
+        pitch, voiced = extract_pitch_contour(self.y, self.sr)
+
+        return {
+            "duration_sec": self.get_duration(),
+            "rms": self.get_rms(),
+            "peak_amplitude": self.get_peak_amplitude(),
+            "spectral_centroid": float(np.mean(spec_centroid)),
+            "spectral_flatness": self.get_spectral_flatness(),
+            "zero_crossing_rate": self.get_zero_crossing_rate(),
+            "dynamic_range_db": self.get_dynamic_range(),
+            "mfccs": self.get_mfccs(),
+            "envelope": envelope.tolist(),
+            "harmonic_rms": float(np.sqrt(np.mean(harmonic ** 2))),
+            "pitch_contour": pitch.tolist() if pitch is not None else None,
+            "voiced_flags": voiced.tolist() if voiced is not None else None,
+            "fft": compute_fft(self.y).tolist(),
+        }
+

--- a/trion/pro_reference_manager.py
+++ b/trion/pro_reference_manager.py
@@ -1,0 +1,99 @@
+# ==============================================================================
+# pro_reference_manager.py - Triōn AI için Referans Yönetimi (Pro Versiyon)
+# ==============================================================================
+
+import json
+import os
+from typing import Dict, Any, Union, List
+import numpy as np
+
+class ProReferenceManager:
+    """
+    Triōn AI'ın 'ses mühendisi' hafızasını yöneten ve referansları
+    karşılaştıran profesyonel sınıf.
+    """
+    def __init__(self, reference_file: str = "trio_ai_references.json"):
+        """
+        Referans yöneticisini başlatır ve referansları yükler.
+
+        Args:
+            reference_file (str): Referansların kaydedileceği/yükleneceği JSON dosya adı.
+        """
+        self.reference_file = reference_file
+        self.references: Dict[str, Dict[str, Any]] = {}
+        self.load_references()
+
+    def add_reference(self, name: str, analysis_dict: Dict[str, Any], metadata: Dict[str, str] = None):
+        """
+        Yeni bir referans analizi ekler veya mevcut olanı günceller.
+
+        Args:
+            name (str): Referansın benzersiz adı.
+            analysis_dict (Dict[str, Any]): Ses analiz sonuçlarını içeren sözlük.
+            metadata (Dict[str, str], optional): Ek metadata.
+        """
+        self.references[name] = {
+            "analysis": analysis_dict,
+            "metadata": metadata if metadata is not None else {}
+        }
+        print(f"Referans eklendi/güncellendi: {name}")
+
+    def save_references(self) -> None:
+        """Referansları JSON dosyasına kaydeder."""
+        try:
+            with open(self.reference_file, 'w', encoding='utf-8') as f:
+                json.dump(self.references, f, indent=4, ensure_ascii=False)
+            print(f"Referanslar başarıyla kaydedildi: {self.reference_file}")
+        except IOError as e:
+            print(f"Hata: Referanslar kaydedilemedi: {e}")
+
+    def load_references(self) -> None:
+        """Referansları JSON dosyasından yükler."""
+        if os.path.exists(self.reference_file):
+            try:
+                with open(self.reference_file, 'r', encoding='utf-8') as f:
+                    self.references = json.load(f)
+                print(f"Referanslar başarıyla yüklendi: {self.reference_file} ({len(self.references)} adet)")
+            except json.JSONDecodeError as e:
+                print(f"Hata: Referans dosyası bozuk veya geçersiz JSON: {e}")
+                self.references = {}
+            except IOError as e:
+                print(f"Hata: Referans dosyası okunamadı: {e}")
+                self.references = {}
+        else:
+            print(f"Referans dosyası bulunamadı: {self.reference_file}. Yeni bir tane oluşturulacak.")
+            self.references = {}
+
+    def get_reference(self, name: str) -> Union[Dict[str, Any], None]:
+        """Belirtilen ada sahip bir referansı döndürür."""
+        return self.references.get(name)
+
+    def compare(self, target_analysis: Dict[str, Union[float, List[float]]]) -> Dict[str, Dict[str, float]]:
+        """
+        Bir hedef analizi, kaydedilmiş tüm referanslarla karşılaştırır ve
+        farklılıkları (mutlak değer) döndürür.
+        """
+        differences: Dict[str, Dict[str, float]] = {}
+
+        numeric_target_analysis = {k: v for k, v in target_analysis.items() if isinstance(v, (int, float))}
+        target_mfccs = target_analysis.get("mfccs", [])
+
+        for ref_name, ref_data in self.references.items():
+            ref_analysis = ref_data.get("analysis", {})
+            diff: Dict[str, float] = {}
+
+            for key, target_val in numeric_target_analysis.items():
+                if key in ref_analysis and isinstance(ref_analysis[key], (int, float)):
+                    diff[key] = abs(ref_analysis[key] - target_val)
+                else:
+                    diff[key] = float('inf')
+
+            ref_mfccs = ref_analysis.get("mfccs", [])
+            if target_mfccs and ref_mfccs and len(target_mfccs) == len(ref_mfccs):
+                diff["mfccs_diff"] = float(np.linalg.norm(np.array(ref_mfccs) - np.array(target_mfccs)))
+            elif target_mfccs or ref_mfccs:
+                diff["mfccs_diff"] = float('inf')
+
+            differences[ref_name] = diff
+        return differences
+

--- a/trion/quantize.py
+++ b/trion/quantize.py
@@ -1,0 +1,33 @@
+# ======================================================================
+# quantize.py - Convert trained models to TFLite with reduced precision
+# ======================================================================
+"""Utility for quantizing trained models for embedded deployment."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+try:
+    import tensorflow as tf
+except Exception:  # pragma: no cover - tensorflow may not be installed
+    tf = None
+
+
+def quantize(saved_model_dir: str, output_path: str, dtype: Literal["int8", "float16"] = "int8") -> str:
+    if tf is None:
+        raise RuntimeError("TensorFlow is required for quantization")
+
+    converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+
+    if dtype == "int8":
+        converter.target_spec.supported_types = [tf.int8]
+    elif dtype == "float16":
+        converter.target_spec.supported_types = [tf.float16]
+    else:
+        raise ValueError("dtype must be 'int8' or 'float16'")
+
+    tflite_model = converter.convert()
+    with open(output_path, "wb") as f:
+        f.write(tflite_model)
+    return output_path

--- a/trion/similarity_matcher.py
+++ b/trion/similarity_matcher.py
@@ -1,0 +1,58 @@
+# =============================================================================
+# similarity_matcher.py - Find the closest reference by audio feature distance
+# =============================================================================
+
+from __future__ import annotations
+
+from typing import Dict, Any, Tuple, List
+
+import numpy as np
+
+from .pro_reference_manager import ProReferenceManager
+
+
+class SimilarityMatcher:
+    """Compare analysis dictionaries to find the most similar reference."""
+
+    def __init__(self, reference_manager: ProReferenceManager) -> None:
+        self.reference_manager = reference_manager
+
+    @staticmethod
+    def _distance(a: Dict[str, Any], b: Dict[str, Any]) -> float:
+        """Return Euclidean distance between two analysis dicts."""
+        dist = 0.0
+        # Numeric keys
+        for key, val in a.items():
+            other = b.get(key)
+            if isinstance(val, (int, float)) and isinstance(other, (int, float)):
+                diff = float(val) - float(other)
+                dist += diff * diff
+            elif isinstance(val, list) and isinstance(other, list):
+                arr_a = np.array(val, dtype=float)
+                arr_b = np.array(other, dtype=float)
+                if arr_a.shape == arr_b.shape:
+                    diff = arr_a - arr_b
+                    dist += float(np.dot(diff, diff))
+        return float(np.sqrt(dist))
+
+    def find_best_match(self, target_analysis: Dict[str, Any]) -> Tuple[str | None, float]:
+        """Return the reference name with the smallest distance and the distance."""
+        best_name: str | None = None
+        best_dist = float("inf")
+        for name, ref in self.reference_manager.references.items():
+            ref_analysis = ref.get("analysis", {})
+            d = self._distance(target_analysis, ref_analysis)
+            if d < best_dist:
+                best_dist = d
+                best_name = name
+        return best_name, best_dist
+
+    def ranked_matches(self, target_analysis: Dict[str, Any]) -> List[Tuple[str, float]]:
+        """Return all references sorted by distance to the target."""
+        scores = []
+        for name, ref in self.reference_manager.references.items():
+            ref_analysis = ref.get("analysis", {})
+            d = self._distance(target_analysis, ref_analysis)
+            scores.append((name, d))
+        scores.sort(key=lambda x: x[1])
+        return scores

--- a/trion/streamlit_gui.py
+++ b/trion/streamlit_gui.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+
+import streamlit as st
+
+from .pro_reference_manager import ProReferenceManager
+from .ai_mapper import AIMapper
+from .preset_exporter import PresetExporter
+from .style_simulator import StyleSimulator
+
+
+def main() -> None:
+    st.title("Triōn AI")
+
+    uploaded_file = st.file_uploader("Ses dosyası yükleyin", type=["wav", "flac", "mp3", "ogg"])
+
+    ref_manager = ProReferenceManager()
+    ref_names = list(ref_manager.references.keys())
+    reference = st.selectbox("Referans", ["Otomatik"] + ref_names)
+
+    model_path = st.text_input("Model path", "model.tflite")
+
+    if uploaded_file is not None:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(uploaded_file.name)[1]) as tmp:
+            tmp.write(uploaded_file.getbuffer())
+            tmp_path = tmp.name
+
+        mapper = AIMapper(model_path=model_path if os.path.exists(model_path) else None)
+        exporter = PresetExporter()
+        simulator = StyleSimulator(ref_manager, mapper, exporter)
+
+        if st.button("Analiz et"):
+            suggestions = simulator.process(
+                tmp_path,
+                None if reference == "Otomatik" else reference,
+            )
+            st.subheader("Önerilen Ayarlar")
+            st.json(suggestions)
+
+            fmt = st.selectbox("Export format", ["json", "xml", "reaper", "vstpreset"])
+            if st.button("Preset indir"):
+                out_file = tempfile.NamedTemporaryFile(delete=False, suffix=f".{fmt}")
+                exporter.export(suggestions, fmt, out_file.name)
+                with open(out_file.name, "rb") as f:
+                    st.download_button("Download", f, file_name=os.path.basename(out_file.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/trion/style_mapper.py
+++ b/trion/style_mapper.py
@@ -1,0 +1,42 @@
+# =============================================================================
+# style_mapper.py - Suggest processing adjustments based on analysis differences
+# =============================================================================
+
+from typing import Dict
+
+class StyleMapper:
+    """Maps analysis differences to simple processing suggestions."""
+
+    def __init__(self,
+                 centroid_thresh: float = 500.0,
+                 rms_thresh: float = 0.1,
+                 dynamic_range_thresh: float = 3.0):
+        self.centroid_thresh = centroid_thresh
+        self.rms_thresh = rms_thresh
+        self.dynamic_range_thresh = dynamic_range_thresh
+
+    def map_differences(self,
+                        target: Dict[str, float],
+                        reference: Dict[str, float]) -> Dict[str, float]:
+        """Return a dict of processing suggestions."""
+        suggestions: Dict[str, float] = {}
+
+        centroid_diff = target.get("spectral_centroid", 0) - reference.get("spectral_centroid", 0)
+        if centroid_diff > self.centroid_thresh:
+            suggestions["eq_high_shelf_db"] = -3.0
+        elif centroid_diff < -self.centroid_thresh:
+            suggestions["eq_high_shelf_db"] = 3.0
+
+        rms_diff = target.get("rms", 0) - reference.get("rms", 0)
+        if rms_diff > self.rms_thresh:
+            suggestions["compressor_ratio"] = 4.0
+        elif rms_diff < -self.rms_thresh:
+            suggestions["compressor_ratio"] = 2.0
+
+        dr_diff = target.get("dynamic_range_db", 0) - reference.get("dynamic_range_db", 0)
+        if dr_diff < -self.dynamic_range_thresh:
+            suggestions["expander_ratio"] = 1.5
+        elif dr_diff > self.dynamic_range_thresh:
+            suggestions["limiter_threshold_db"] = -1.0
+
+        return suggestions

--- a/trion/style_simulator.py
+++ b/trion/style_simulator.py
@@ -1,0 +1,55 @@
+# =============================================================================
+# style_simulator.py - Orchestrates analysis and preset generation
+# =============================================================================
+
+from typing import Dict, Optional
+from .pro_audio_analyzer import ProAudioAnalyzer
+from .pro_reference_manager import ProReferenceManager
+from .ai_mapper import AIMapper
+from .preset_exporter import PresetExporter
+from .similarity_matcher import SimilarityMatcher
+
+
+class StyleSimulator:
+    """Runs an analysis against a reference and exports preset suggestions."""
+
+    def __init__(self,
+                 reference_manager: ProReferenceManager,
+                 mapper: AIMapper,
+                 exporter: PresetExporter):
+        self.reference_manager = reference_manager
+        self.mapper = mapper
+        self.exporter = exporter
+        self.matcher = SimilarityMatcher(reference_manager)
+
+    def process(
+        self,
+        audio_path: str,
+        reference_name: Optional[str] = None,
+        export_format: str | None = None,
+        export_path: str | None = None,
+    ) -> Dict[str, float]:
+        analyzer = ProAudioAnalyzer(audio_path)
+        analysis = analyzer.analyze()
+
+        if reference_name is not None:
+            reference = self.reference_manager.get_reference(reference_name)
+            if reference is None:
+                raise ValueError(f"Reference not found: {reference_name}")
+            references = {reference_name: reference}
+        else:
+            best, _ = self.matcher.find_best_match(analysis)
+            if best is None:
+                raise ValueError("No references available")
+            reference = self.reference_manager.get_reference(best)
+            references = {best: reference}
+
+        suggestions = self.mapper.suggest_processing(
+            analysis,
+            references,
+        )
+
+        if export_format and export_path:
+            self.exporter.export(suggestions, export_format, export_path)
+
+        return suggestions

--- a/trion/ton_shaper.py
+++ b/trion/ton_shaper.py
@@ -1,0 +1,43 @@
+# ======================================================================
+# ton_shaper.py - Simple audio post-processing utilities
+# ======================================================================
+"""Functions for EQ, saturation and other tone shaping operations."""
+
+from __future__ import annotations
+
+import numpy as np
+import scipy.signal
+
+
+def apply_eq(audio: np.ndarray, sr: int, freq: float, gain_db: float) -> np.ndarray:
+    """Apply a single band peaking EQ."""
+    q = 1.0
+    gain = 10 ** (gain_db / 40)
+    b, a = scipy.signal.iirpeak(freq / (sr / 2), q, gain)
+    return scipy.signal.lfilter(b, a, audio)
+
+
+def saturate(audio: np.ndarray, amount: float = 0.5) -> np.ndarray:
+    return np.tanh(audio * (1 + amount))
+
+
+def compress(audio: np.ndarray, threshold_db: float = -20.0, ratio: float = 4.0) -> np.ndarray:
+    linear_thresh = 10 ** (threshold_db / 20)
+    gain = np.ones_like(audio)
+    over = np.abs(audio) > linear_thresh
+    gain[over] = (linear_thresh + (np.abs(audio[over]) - linear_thresh) / ratio) / np.abs(audio[over])
+    return audio * gain
+
+
+def add_reverb(audio: np.ndarray, sr: int, mix: float = 0.1) -> np.ndarray:
+    ir = np.exp(-np.linspace(0, 3, int(sr * 0.5)))
+    wet = np.convolve(audio, ir)[: len(audio)]
+    return (1 - mix) * audio + mix * wet
+
+
+def widen_stereo(audio_l: np.ndarray, audio_r: np.ndarray, width: float = 1.0) -> tuple[np.ndarray, np.ndarray]:
+    mid = (audio_l + audio_r) / 2
+    side = (audio_l - audio_r) / 2 * width
+    left = mid + side
+    right = mid - side
+    return left, right

--- a/trion/train.py
+++ b/trion/train.py
@@ -1,0 +1,51 @@
+# ======================================================================
+# train.py - Training utilities for Tri\u014dn AI model
+# ======================================================================
+"""Training script for the lightweight model with simple augmentation."""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+import numpy as np
+
+try:
+    import tensorflow as tf
+except Exception:  # pragma: no cover - tensorflow may not be installed
+    tf = None
+
+from .model_arch import build_model
+
+
+def load_dataset(path: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Load features and labels from .npz files in ``path``."""
+    feats = []
+    labels = []
+    for fname in os.listdir(path):
+        if fname.endswith(".npz"):
+            data = np.load(os.path.join(path, fname))
+            feats.append(data["features"])
+            labels.append(data["labels"])
+    return np.vstack(feats), np.vstack(labels)
+
+
+def augment(features: np.ndarray) -> np.ndarray:
+    noise = np.random.normal(scale=0.01, size=features.shape)
+    return features + noise
+
+
+def train(data_path: str, out_path: str, epochs: int = 10) -> str:
+    if tf is None:
+        raise RuntimeError("TensorFlow is required for training")
+
+    x, y = load_dataset(data_path)
+    x_aug = augment(x)
+    x_train = np.concatenate([x, x_aug], axis=0)
+    y_train = np.concatenate([y, y], axis=0)
+
+    model = build_model(x.shape[1], y.shape[1])
+    model.compile(optimizer="adam", loss="mse")
+    model.fit(x_train, y_train, batch_size=32, epochs=epochs)
+    model.save(out_path)
+    return out_path


### PR DESCRIPTION
## Summary
- allow `ProAudioAnalyzer` to retain stereo when desired
- use advanced audio analysis when adding references
- add dataset builder utility
- enhance DSP helpers and comprehensive tests
- include pytest and expose dataset builder
- make CLI reference optional and allow model path argument

## Testing
- `python -m py_compile trion/*.py src/*.py main.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5f6c8848832dac22ea245eb26478